### PR TITLE
Updated path for explorer directory in deploy.md section Deploy qtuminfo

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -12,7 +12,7 @@
 ## Deploy qtuminfo
 1. `git clone https://github.com/qtumproject/qtuminfo.git && cd qtuminfo`
 2. `npm install`
-3. `mkdir explorer` (you may change the directory name) and write files `package.json` and `qtuminfo-node.json` to it
+3. `mkdir packages/explorer` (you may change the directory name) and write files `package.json` and `qtuminfo-node.json` to it
     ```json
     // package.json
     {


### PR DESCRIPTION
explorer directory should be created in packages directory, which would be consistent with point 5 (run `npm start` in `packages/explorer` directory)