### PR TITLE
Updated version of MongoDB in Prequisites

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 * node.js v10.5+
-* mongodb v3.6+
+* mongodb v4.0+
 
 ## Deploy qtum core
 1. `git clone --recursive https://github.com/xuanyan0x7c7/qtum.git`


### PR DESCRIPTION
Using MongoDB 3.6.x results in an error  `MongoError: Unrecognized expression '$toBool'`

Per Jackson Belove:  $toBool was new in MongoDB version 4.0